### PR TITLE
fix HistoricDeposit type

### DIFF
--- a/BittrexSharp/Domain/HistoricDeposit.cs
+++ b/BittrexSharp/Domain/HistoricDeposit.cs
@@ -1,21 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BittrexSharp.Domain
 {
     public class HistoricDeposit
     {
-        public string PaymentUuid { get; set; }
-        public string Currency { get; set; }
+        public long Id { get; set; }
         public decimal Amount { get; set; }
-        public string Address { get; set; }
-        public DateTime Opened { get; set; }
-        public bool Authorized { get; set; }
-        public bool PendingPayment { get; set; }
-        public decimal TxCost { get; set; }
+        public string Currency { get; set; }
+        public int Confirmations { get; set; }
+        public DateTime LastUpdated { get; set; }
         public string TxId { get; set; }
-        public bool Canceled { get; set; }
-        public bool InvalidAddress { get; set; }
+        public string CryptoAddress { get; set; }
     }
 }


### PR DESCRIPTION
Description of getdeposithistory request in [offical documentation](https://bittrex.com/Home/Api) has an error. It's duplicate of description of getwithdrawalhistory request. 

Really, getdeposithistory response looks like:
```json
{
    "success": true,
    "message": "",
    "result": [
        {
            "Id": 11111,
            "Amount": 0.2,
            "Currency": "BTC",
            "Confirmations": 2,
            "LastUpdated": "2017-11-29T08:10:54.277",
            "TxId": "b4a575c2a71c7e56d02ab8e26bb1ef0a2f6cf2094f6ca2116476a569c1e84f6e",
            "CryptoAddress": "XVnSMgAd7EonF2Dgc4c9K14L12RBaW5S5J"
        }
    ]
}
```